### PR TITLE
Fixup for ASCII art title on Safari Desktop

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -48,6 +48,7 @@ html {
   font-size: 10.5px;
   line-height: 1;
   overflow: hidden;
+  display: inline-block;
 }
 
 .mobile-ascii-title {


### PR DESCRIPTION
Specifying `inline-block` leads to something that works on Safari desktop, Firefox, and Chromium.